### PR TITLE
Add copy button and tooltip for code snippets

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -62,7 +62,10 @@ This doesn't include the `_config.yml` though, as we're expected to set custom s
 Here's a list of places I've changed code. This typically meant copying the file from the forked minimal-mistakes repo and overriding parts of it:
 
 - `_data/navigation.yml`: Added Home navigation menu item and commented out Tags.
-- `_includes/footer.html`: Added advertisements and Donate sections to the bottom of the footer.
+- `_includes/footer.html`: Added code to the bottom of the file that:
+  - Adds advertisements.
+  - Adds a Donate section.
+  - Dynamically adds a "Copy to clipboard" button to all code blocks.
 - `_includes/masthead.html`: Added site description below site title.
 - `_layouts/home.html`: Added id to 'Recent Posts' heading so we can adjust whitespace around it.
 - `_config.yml` file.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -59,7 +59,7 @@ Currently with the MinimalMistakes theme we are not installing it from a gem, bu
 Anywhere that I make custom code changes, I try to put `Dan's Customizations` in comments, so doing a search of the repo for `Dan` should find all places I've changed / overwritten code.
 This doesn't include the `_config.yml` though, as we're expected to set custom settings in there.
 
-Here's a list of places I've changed code:
+Here's a list of places I've changed code. This typically meant copying the file from the forked minimal-mistakes repo and overriding parts of it:
 
 - `_data/navigation.yml`: Added Home navigation menu item and commented out Tags.
 - `_includes/footer.html`: Added advertisements and Donate sections to the bottom of the footer.
@@ -77,7 +77,7 @@ Here's a list of files I've added:
 
 - Everything in the `_posts` and `_drafts` directories.
 - The `_pages\About.md` page.
-- Everything in the `_assets\Posts` and `_assets\Site` directories.
+- Everything in the `_assets\Posts`, `_assets\Site`, and `_assets\js` directories.
 - Everything in the `_data\comments` directory.
 - The `favicon.ico` image.
 - The `.vscode` directory.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -46,6 +46,9 @@
 </div>
 <script src="/assets/js/Donate.js" defer></script>
 
+<!-- Add buttons for copying code snippets to the clipboard. -->
+<script src="/assets/js/AddCopyToClipboardButtons.js" defer></script>
+
 <!-- This code is here instead of in `_includes\footer\custom.html` so that advertisement appear at the VERY bottom of the page. -->
 <!-- Put some advertisements at the bottom of the site -->
 <div style="text-align: center; margin-top: 1em">

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -90,6 +90,53 @@ kbd
 	font-weight: bolder;
 }
 
+.CopyCodeSnippetToClipboardButton.Tooltip
+{
+	position: relative;	// Ensure the TooltipText element's position is relative to the element that has the tooltip.
+}
+
+.CopyCodeSnippetToClipboardButton.Tooltip .TooltipText
+{
+	color: #555;
+	background-color: #fff;
+	text-align: center;
+	border-radius: 6px;
+	padding: 0.3em 0.5em;
+	z-index: 1;	// Ensure the TooltipText shows up on top of any other elements.
+
+	position: absolute;
+	right: 100%;	// Ensure text shows up to the left of the element with the Tooltip.
+	margin-right: 1em;	// Give a bit more padding so the Tooltip doesn't touch the element with the Tooltip.
+	top: 50%;	// Center the tooltip vertically with the Tooltip element.
+	transform: translateY(-50%);
+
+	visibility: hidden;
+	opacity: 0;
+	transition: opacity 0.3s;
+}
+
+// The little arrow on the tooltip that points toward it's element that makes it look like a speech bubble.
+.CopyCodeSnippetToClipboardButton.Tooltip .TooltipText::after
+{
+	content: ""; // Doesn't show up if the content is not set.
+	position: absolute;
+
+	left: 100%;	// Make sure the arrow shows up on the right side of the TooltipText.
+	top: 50%;	// Center the arrow vertically with the TooltipText.
+	transform: translateY(-50%);
+
+	height: 0.1em;
+	border-style: solid;
+	border-color: transparent transparent transparent #fff;
+}
+
+// Show the TooltipText when the hovering over the Tooltip element.
+.CopyCodeSnippetToClipboardButton.Tooltip:hover .TooltipText
+{
+	visibility: visible;
+	opacity: 1;
+}
+
 // Have a fixed donate section on all of the pages (always on-top on bottom-left).
 #Donate
 {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -78,6 +78,18 @@ kbd
 	text-shadow:0 1px 0 #fff;
 }
 
+// Style for our dynamically generated Copy Code Snippet buttons.
+.CopyCodeSnippetToClipboardButton
+{
+	float: right;
+	cursor: pointer;
+}
+
+.CopyCodeSnippetToClipboardButton:hover
+{
+	font-weight: bolder;
+}
+
 // Have a fixed donate section on all of the pages (always on-top on bottom-left).
 #Donate
 {

--- a/assets/js/AddCopyToClipboardButtons.js
+++ b/assets/js/AddCopyToClipboardButtons.js
@@ -9,17 +9,28 @@ allCodeElements.forEach((codeElement, index, parent) => {
 	var codeElementId = `dynamicCodeElement${index}`
 	codeElement.setAttribute("id", codeElementId);
 
-	// Instead of using a real button we use an <i> element, as per Font Awesome's instructions: https://fontawesome.com/v3.2.1/examples/
-	var buttonElement = document.createElement("i");
-	buttonElement.addEventListener('click', function () { CopyElementTextToClipboard(codeElementId) });
-	buttonElement.classList = 'CopyCodeSnippetToClipboardButton far fa-copy'	// https://fontawesome.com/icons/copy?style=regular
-	codeElement.prepend(buttonElement);
+	AddCopyCodeSnippetButtonToCodeElement(codeElement, codeElementId)
 });
 
 function IsFencedCodeBlock(codeElement)
 {
 	// Inline code snippets have a class name, but code blocks do not.
 	return (codeElement.className ? false : true);
+}
+
+function AddCopyCodeSnippetButtonToCodeElement(codeElement, codeElementId)
+{
+	// Instead of using a real button we use an <i> element, as per Font Awesome's instructions: https://fontawesome.com/v3.2.1/examples/
+	var buttonElement = document.createElement("i");
+	buttonElement.addEventListener('click', function () { CopyElementTextToClipboard(codeElementId) });
+	buttonElement.classList = 'CopyCodeSnippetToClipboardButton Tooltip far fa-copy'	// https://fontawesome.com/icons/copy?style=regular
+	codeElement.prepend(buttonElement);
+
+	// Add the button tooltip.
+	var tooltipElement = document.createElement("span");
+	tooltipElement.textContent = "Copy code snippet to clipboard"
+	tooltipElement.classList = "TooltipText";
+	buttonElement.appendChild(tooltipElement);
 }
 
 function CopyElementTextToClipboard(domElementId)

--- a/assets/js/AddCopyToClipboardButtons.js
+++ b/assets/js/AddCopyToClipboardButtons.js
@@ -1,0 +1,45 @@
+
+var allCodeElements = document.querySelectorAll("code");
+allCodeElements.forEach((codeElement, index, parent) => {
+
+	if (!IsFencedCodeBlock(codeElement))
+		return;
+
+	// Assign the <code> element a unique ID so we can reference it when clicked.
+	var codeElementId = `dynamicCodeElement${index}`
+	codeElement.setAttribute("id", codeElementId);
+
+	// Instead of using a real button we use an <i> element, as per Font Awesome's instructions: https://fontawesome.com/v3.2.1/examples/
+	var buttonElement = document.createElement("i");
+	buttonElement.addEventListener('click', function () { CopyElementTextToClipboard(codeElementId) });
+	buttonElement.classList = 'CopyCodeSnippetToClipboardButton far fa-copy'	// https://fontawesome.com/icons/copy?style=regular
+	codeElement.prepend(buttonElement);
+});
+
+function IsFencedCodeBlock(codeElement)
+{
+	// Inline code snippets have a class name, but code blocks do not.
+	return (codeElement.className ? false : true);
+}
+
+function CopyElementTextToClipboard(domElementId)
+{
+	var element = document.getElementById(domElementId);
+	if (!element)
+	{
+		console.error(`Could not find the element to copy text to clipboard for. Specified element ID was '${domElementId}'.`);
+	}
+
+	var textToCopyToClipboard = element.innerText
+
+	navigator.clipboard.writeText(textToCopyToClipboard).then(
+		function ()
+		{
+			console.log('Copying to clipboard was successful!');
+		},
+		function (error)
+		{
+			console.error('Could not copy text to clipboard.', error);
+		}
+	);
+}

--- a/assets/js/AddCopyToClipboardButtons.js
+++ b/assets/js/AddCopyToClipboardButtons.js
@@ -3,7 +3,6 @@
 var allCodeElements = document.querySelectorAll("code");
 allCodeElements.forEach((codeElement, index, parent) =>
 {
-
 	if (!IsFencedCodeBlock(codeElement))
 		return;
 

--- a/assets/js/AddCopyToClipboardButtons.js
+++ b/assets/js/AddCopyToClipboardButtons.js
@@ -6,11 +6,7 @@ allCodeElements.forEach((codeElement, index, parent) => {
 	if (!IsFencedCodeBlock(codeElement))
 		return;
 
-	// Assign the <code> element a unique ID so we can reference it when clicked.
-	var codeElementId = `dynamicCodeElement${index}`;
-	codeElement.setAttribute("id", codeElementId);
-
-	AddCopyCodeSnippetButtonToCodeElement(codeElement, codeElementId)
+	AddCopyCodeSnippetButtonToCodeElement(codeElement);
 });
 
 function IsFencedCodeBlock(codeElement)
@@ -19,12 +15,18 @@ function IsFencedCodeBlock(codeElement)
 	return (codeElement.className ? false : true);
 }
 
-function AddCopyCodeSnippetButtonToCodeElement(codeElement, codeElementId)
+function AddCopyCodeSnippetButtonToCodeElement(codeElement)
 {
+	// Grab the Code Element's text before it's DOM is modified by anything, such as the Tooltip.
+	// This may not be the most performant way to do this, as it will keep all code snippet text in memory in the
+	// anonymous function defined below, but it's definitely the simplest. If we find this causes problems, we can
+	// change back to storing only the codeElement.id and dynamically retrieving the contents in the CopyTextToClipboard function.
+	var textToCopyToClipboard = codeElement.innerText;
+
 	// Instead of using a real button we use an <i> element, as per Font Awesome's instructions: https://fontawesome.com/v3.2.1/examples/
 	var buttonElement = document.createElement("i");
-	buttonElement.addEventListener('click', function () { CopyElementTextToClipboard(codeElementId) });
-	buttonElement.classList = 'CopyCodeSnippetToClipboardButton Tooltip far fa-copy'	// https://fontawesome.com/icons/copy?style=regular
+	buttonElement.addEventListener('click', function () { CopyTextToClipboard(textToCopyToClipboard) });
+	buttonElement.classList = 'CopyCodeSnippetToClipboardButton Tooltip far fa-copy';	// https://fontawesome.com/icons/copy?style=regular
 	codeElement.prepend(buttonElement);
 
 	// Add the button tooltip.
@@ -34,16 +36,8 @@ function AddCopyCodeSnippetButtonToCodeElement(codeElement, codeElementId)
 	buttonElement.appendChild(tooltipElement);
 }
 
-function CopyElementTextToClipboard(domElementId)
+function CopyTextToClipboard(textToCopyToClipboard)
 {
-	var element = document.getElementById(domElementId);
-	if (!element)
-	{
-		console.error(`Could not find the element to copy text to clipboard for. Specified element ID was '${domElementId}'.`);
-	}
-
-	var textToCopyToClipboard = element.innerText
-
 	navigator.clipboard.writeText(textToCopyToClipboard).then(
 		function ()
 		{

--- a/assets/js/AddCopyToClipboardButtons.js
+++ b/assets/js/AddCopyToClipboardButtons.js
@@ -23,17 +23,24 @@ function AddCopyCodeSnippetButtonToCodeElement(codeElement)
 	// change back to storing only the codeElement.id and dynamically retrieving the contents in the CopyTextToClipboard function.
 	var textToCopyToClipboard = codeElement.innerText;
 
+	// Create the button tooltip.
+	var tooltipElement = document.createElement("span");
+	tooltipElement.classList = "TooltipText";
+
+	// Create the button.
 	// Instead of using a real button we use an <i> element, as per Font Awesome's instructions: https://fontawesome.com/v3.2.1/examples/
 	var buttonElement = document.createElement("i");
-	buttonElement.addEventListener('click', function () { CopyTextToClipboard(textToCopyToClipboard) });
+	buttonElement.addEventListener('click', function ()
+		{
+			CopyTextToClipboard(textToCopyToClipboard);
+			tooltipElement.textContent = "Text copied to clipboard"
+		});
+	buttonElement.addEventListener('mouseenter', function () { tooltipElement.textContent = "Copy code snippet to clipboard" });
 	buttonElement.classList = 'CopyCodeSnippetToClipboardButton Tooltip far fa-copy';	// https://fontawesome.com/icons/copy?style=regular
-	codeElement.prepend(buttonElement);
 
-	// Add the button tooltip.
-	var tooltipElement = document.createElement("span");
-	tooltipElement.textContent = "Copy code snippet to clipboard";
-	tooltipElement.classList = "TooltipText";
+	// Add the dynamic elements to the DOM.
 	buttonElement.appendChild(tooltipElement);
+	codeElement.prepend(buttonElement);
 }
 
 function CopyTextToClipboard(textToCopyToClipboard)

--- a/assets/js/AddCopyToClipboardButtons.js
+++ b/assets/js/AddCopyToClipboardButtons.js
@@ -1,4 +1,5 @@
-
+// Once DOM has finished loading (by using 'defer' to reference this script), collect all code block elements
+// and dynamically attach buttons to them for copying the code snippet text to the clipboard.
 var allCodeElements = document.querySelectorAll("code");
 allCodeElements.forEach((codeElement, index, parent) => {
 
@@ -6,7 +7,7 @@ allCodeElements.forEach((codeElement, index, parent) => {
 		return;
 
 	// Assign the <code> element a unique ID so we can reference it when clicked.
-	var codeElementId = `dynamicCodeElement${index}`
+	var codeElementId = `dynamicCodeElement${index}`;
 	codeElement.setAttribute("id", codeElementId);
 
 	AddCopyCodeSnippetButtonToCodeElement(codeElement, codeElementId)
@@ -28,7 +29,7 @@ function AddCopyCodeSnippetButtonToCodeElement(codeElement, codeElementId)
 
 	// Add the button tooltip.
 	var tooltipElement = document.createElement("span");
-	tooltipElement.textContent = "Copy code snippet to clipboard"
+	tooltipElement.textContent = "Copy code snippet to clipboard";
 	tooltipElement.classList = "TooltipText";
 	buttonElement.appendChild(tooltipElement);
 }

--- a/assets/js/AddCopyToClipboardButtons.js
+++ b/assets/js/AddCopyToClipboardButtons.js
@@ -1,7 +1,8 @@
 // Once DOM has finished loading (by using 'defer' to reference this script), collect all code block elements
 // and dynamically attach buttons to them for copying the code snippet text to the clipboard.
 var allCodeElements = document.querySelectorAll("code");
-allCodeElements.forEach((codeElement, index, parent) => {
+allCodeElements.forEach((codeElement, index, parent) =>
+{
 
 	if (!IsFencedCodeBlock(codeElement))
 		return;
@@ -23,36 +24,35 @@ function AddCopyCodeSnippetButtonToCodeElement(codeElement)
 	// change back to storing only the codeElement.id and dynamically retrieving the contents in the CopyTextToClipboard function.
 	var textToCopyToClipboard = codeElement.innerText;
 
-	// Create the button tooltip.
-	var tooltipElement = document.createElement("span");
-	tooltipElement.classList = "TooltipText";
+	var buttonTooltipElement = document.createElement("span");
+	buttonTooltipElement.classList = "TooltipText";
 
-	// Create the button.
 	// Instead of using a real button we use an <i> element, as per Font Awesome's instructions: https://fontawesome.com/v3.2.1/examples/
 	var buttonElement = document.createElement("i");
-	buttonElement.addEventListener('click', function ()
-		{
-			CopyTextToClipboard(textToCopyToClipboard);
-			tooltipElement.textContent = "Text copied to clipboard"
-		});
-	buttonElement.addEventListener('mouseenter', function () { tooltipElement.textContent = "Copy code snippet to clipboard" });
 	buttonElement.classList = 'CopyCodeSnippetToClipboardButton Tooltip far fa-copy';	// https://fontawesome.com/icons/copy?style=regular
+	buttonElement.addEventListener('click',
+		function () { CopyTextToClipboardAndUpdateTooltip(textToCopyToClipboard, buttonTooltipElement); });
 
-	// Add the dynamic elements to the DOM.
-	buttonElement.appendChild(tooltipElement);
+	// The click event will update the tooltip text, so reset it when the mouse re-enters the button.
+	buttonElement.addEventListener('mouseenter',
+		function () { buttonTooltipElement.textContent = "Copy code snippet to clipboard" });
+
+	// Add the dynamically created elements to the DOM.
+	buttonElement.appendChild(buttonTooltipElement);
 	codeElement.prepend(buttonElement);
 }
 
-function CopyTextToClipboard(textToCopyToClipboard)
+function CopyTextToClipboardAndUpdateTooltip(textToCopyToClipboard, tooltipElement)
 {
 	navigator.clipboard.writeText(textToCopyToClipboard).then(
 		function ()
 		{
-			console.log('Copying to clipboard was successful!');
+			tooltipElement.textContent = "Text copied to clipboard"
 		},
 		function (error)
 		{
 			console.error('Could not copy text to clipboard.', error);
+			tooltipElement.textContent = "Problem occurred copying text to clipboard"
 		}
 	);
 }

--- a/assets/js/Donate.js
+++ b/assets/js/Donate.js
@@ -46,5 +46,5 @@ function CloseDonateModal()
 
 function DonateModalIsOpen()
 {
-	return donateModal.style.display == "block"
+	return donateModal.style.display == "block";
 }


### PR DESCRIPTION
This PR adds a Copy To Clipboard button to all code block snippets, along with a tooltip for the button saying what it does.