### PR TITLE
fix: Grab the post title from the file contents instead of the file name

### DIFF
--- a/Scripts/RenameBlogPost.ps1
+++ b/Scripts/RenameBlogPost.ps1
@@ -15,7 +15,11 @@ Write-Output "The following post will be renamed: $($postToRename.Name)"
 [string] $newPostDate = Read-Host -Prompt "What should the date of the blog post be? (yyyy-MM-dd). Leave blank to use today's date"
 
 if ([string]::IsNullOrWhiteSpace($newPostTitle)) {
-	$newPostTitle = $postToRename.Name.Substring(10) # The first 10 characters are the date: yyyy-MM-dd
+	$newPostTitle =
+		Get-Content -Path $postToRename.FullName |
+		Select-String -Pattern '^title: \"(.+)\"' | # Capture the title line of the post.
+		Select-Object -First 1 | # Only get the first 'title: ' line match.
+		ForEach-Object { $_.Matches.Groups[1].Value } # Return the captured title.
 }
 
 if ([string]::IsNullOrWhiteSpace($newPostDate)) {


### PR DESCRIPTION
fix: Grab the post title from the file contents instead of the file name, to avoid unnecessary hyphens